### PR TITLE
Sift masked

### DIFF
--- a/SiftMasked.h
+++ b/SiftMasked.h
@@ -74,7 +74,7 @@ public:
     }
 
     //find and return features of an image given a binary mask
-    vector<KeyPoint> findFeatures(const Mat &img, const Mat& mask, Mat &descriptor_img, Mat &result_img) {
+    vector<KeyPoint> findFeatures(const Mat &img, const Mat& mask, Mat &descriptor_img) {
         vector<KeyPoint> keypoints_img;
 
         Ptr<Feature2D> f2d = SIFT::create();


### PR DESCRIPTION
Ho creato la classe per trovare le features in specifiche zone di interesse dell’immagine. Vi passo anche in un branch a parte un possibile test se volete provare a vedere come funziona, visualizzando i keypoints con la funzione `cv::drawKeypoints`.
Nella classe ho anche inserito il metodo scritto da Samuele per un’immagine binaria, anche se, ripensandoci oggi, forse non è nemmeno necessario perché potrebbe bastare anche solo l’immagine (se questa è binaria) come maschera per il SIFT, magari ditemi anche voi cosa ne pensate.
Poi ho pensato che per le immagini del dataset potremmo sfruttare le coordinate dei rect salvate nei txt. Quindi, per quel motivo, ho implementato la funzione `checkFileBB` che ritorna il vettore di rects, che si trovano all'interno di un txt passato come secondo argomento alla command line. Successivamente viene creata una binary mask con 1 all’interno dei rect e 0 al di fuori di essi. 
La maschera binaria viene poi data al metodo `findFeatures` che trova keypoints e descriptors nelle zone di interesse.